### PR TITLE
Line Breaks inserted in the logs

### DIFF
--- a/vumi_wikipedia/wikipedia.py
+++ b/vumi_wikipedia/wikipedia.py
@@ -324,7 +324,7 @@ class WikipediaWorker(ApplicationWorker):
         log_parts = [
             'WIKI', self.hash_user(msg.user()), msg['transport_name'],
             msg['transport_type'], msg.get('provider', ''),
-            action, msg['content'],
+            action, repr(msg['content']),
         ] + [u'%s=%r' % (k, v) for (k, v) in kw.items()]
 
         log.msg(u'\t'.join(unicode(s) for s in log_parts).encode('utf8'))


### PR DESCRIPTION
Log files sometimes contain unexpected line breaks (LFs), usually in this form. Note the \t and \n that i inserted. I think we should somehow escape \n, such as each_value.replace('\n', ' ').trim(). Or maybe replace('\n', '\r')? Although later might not be handled correctly by various readline() methods.

2013-10-10 04:59:24+0000 [VumiRedis,client] WIKI    5XXXd   airtel_ke_sms_transport sms     more-no-session\t\n
\tASSETS 

2013-10-28 07:17:23+0000 [HTTP11ClientProtocol,client] WIKI 5XXXd   airtel_ke_sms_transport sms     smscontent\t\n
\t7660  content=u'...'  more=False
