### PR TITLE
Request to not log things with repr()

### DIFF
--- a/vumi_wikipedia/tests/test_wikipedia.py
+++ b/vumi_wikipedia/tests/test_wikipedia.py
@@ -12,7 +12,7 @@ from vumi.message import TransportUserMessage
 from vumi.tests.helpers import VumiTestCase
 from vumi.tests.utils import LogCatcher
 
-from vumi_wikipedia.wikipedia import WikipediaWorker
+from vumi_wikipedia.wikipedia import WikipediaWorker, log_escape
 from vumi_wikipedia.tests.test_wikipedia_api import (
     FakeHTTPTestCaseMixin, WIKIPEDIA_RESPONSES)
 
@@ -622,7 +622,7 @@ class WikipediaWorkerTestCase(VumiTestCase, FakeHTTPTestCaseMixin):
             self.assertEqual(
                 'WIKI\tfoo\tsphex\tussd\t\tstart\tNone', entry1['message'][0])
             self.assertEqual(
-                ("WIKI\tfoo\tsphex\tussd\t\ttitles\tu'\\tcthulhu\\n'\tfound=9"
+                ("WIKI\tfoo\tsphex\tussd\t\ttitles\t\\tcthulhu\\n\tfound=9"
                  "\tshown=6"), entry2['message'][0])
 
     @inlineCallbacks
@@ -635,3 +635,12 @@ class WikipediaWorkerTestCase(VumiTestCase, FakeHTTPTestCaseMixin):
         self.assertEqual(api.gzip, worker_config.accept_gzip)
         self.assertEqual(api.user_agent, worker_config.user_agent)
         self.assertEqual(api.api_timeout, worker_config.api_timeout)
+
+    def test_log_escape(self):
+        self.assertEqual('None', log_escape(None))
+        self.assertEqual('{}', log_escape({}))
+        self.assertEqual('', log_escape(''))
+        self.assertEqual('"', log_escape('"'))
+        self.assertEqual("'", log_escape("'"))
+        self.assertEqual('"\'', log_escape('"\''))
+        self.assertEqual('"\'', log_escape(u'"\''))

--- a/vumi_wikipedia/wikipedia.py
+++ b/vumi_wikipedia/wikipedia.py
@@ -25,6 +25,20 @@ def mkmenu(options, prefix, start=1):
         ['%s. %s' % (idx, opt) for idx, opt in enumerate(options, start)])
 
 
+def log_escape(obj):
+    """
+    Wrapper around repr() that makes the parser less unhappy with strings.
+    """
+    text = repr(obj)
+    if isinstance(obj, basestring):
+        quote = text[-1]
+        if text[0] != quote:
+            text = text[1:]
+        text = text[1:-1]
+        return text.replace('\\' + quote, quote)
+    return text
+
+
 class WikipediaConfig(ApplicationWorker.CONFIG_CLASS):
     api_url = ConfigUrl(
         "URL for the MediaWiki API to query. This defaults to the English"
@@ -336,8 +350,8 @@ class WikipediaWorker(ApplicationWorker):
         log_parts = [
             'WIKI', self.hash_user(msg.user()), msg['transport_name'],
             msg['transport_type'], msg.get('provider', ''),
-            action, repr(msg['content']),
-        ] + [u'%s=%r' % (k, v) for (k, v) in kw.items()]
+            action, log_escape(msg['content']),
+        ] + [u'%s=%s' % (k, log_escape(v)) for (k, v) in kw.items()]
 
         log.msg(u'\t'.join(unicode(s) for s in log_parts).encode('utf8'))
 


### PR DESCRIPTION
It's making @nyurik 's log parsing more difficult. Everything's logged as `utf-8` anyway so there's maybe a chance we can get away without using `%r`.
