### PR TITLE
Ensure leading space for Reply More text in SMS

### DIFF
--- a/vumi_wikipedia/tests/test_wikipedia.py
+++ b/vumi_wikipedia/tests/test_wikipedia.py
@@ -245,6 +245,32 @@ class WikipediaWorkerTestCase(VumiTestCase, FakeHTTPTestCaseMixin):
         })
 
     @inlineCallbacks
+    def test_include_url_in_sms_no_suffix_space(self):
+        yield self.setup_application({
+            'include_url_in_sms': True,
+            'msg_more_content_suffix': '(reply for more)',
+        })
+        yield self.start_session()
+        yield self.assert_response('cthulhu', CTHULHU_RESULTS)
+        yield self.assert_response('1', CTHULHU_SECTIONS)
+        yield self.assert_response('2', CTHULHU_USSD)
+
+        [sms_msg] = self.get_outbound_msgs('sms_content')
+        self.assertEqual(CTHULHU_SMS_WITH_URL, sms_msg['content'])
+        self.assertEqual('+41791234567', sms_msg['to_addr'])
+        yield self.assert_metrics({
+            'ussd_session_start': 1,
+            'ussd_session_search': 1,
+            'ussd_session_results': 1,
+            'ussd_session_results.1': 1,
+            'ussd_session_sections': 1,
+            'ussd_session_sections.2': 1,
+            'ussd_session_content': 1,
+            'wikipedia_search_call': (0, 1),
+            'wikipedia_extract_call': (0, 1),
+        })
+
+    @inlineCallbacks
     def test_different_host_for_sms_url(self):
         yield self.setup_application({
             'include_url_in_sms': True,

--- a/vumi_wikipedia/wikipedia.py
+++ b/vumi_wikipedia/wikipedia.py
@@ -542,8 +542,8 @@ class WikipediaWorker(ApplicationWorker):
             fullurl = self.process_fullurl(config, session['fullurl'])
 
         if fullurl:
-            more_suffix = ' ' + fullurl + more_suffix
-            no_more_suffix = ' ' + fullurl + no_more_suffix
+            more_suffix = ' %s %s' % (fullurl, more_suffix.lstrip(' '))
+            no_more_suffix = ' %s %s' % (fullurl, no_more_suffix.lstrip(' '))
 
         content_len, sms_content = self.get_sms_formatter(config).format_more(
             session['sms_content'], session['sms_offset'],


### PR DESCRIPTION
Example SMS:

```
Some of these were: pegged construction,
English welted (machine-made versions 
are referred to as "Goodyear welted" 
after the inventor of the technique), 
goyser welted, Norwegian, ...Reply 1 for more
```
