### PR TITLE
ContentFormatter spins forever on long words

### DIFF
--- a/vumi_wikipedia/tests/test_text_manglers.py
+++ b/vumi_wikipedia/tests/test_text_manglers.py
@@ -1,10 +1,10 @@
 from twisted.trial.unittest import TestCase
 
-from vumi_wikipedia.text_manglers import (convert_unicode,
-    normalize_whitespace, is_unicode, ContentFormatter)
+from vumi_wikipedia.text_manglers import (
+    convert_unicode, normalize_whitespace, is_unicode, ContentFormatter)
 
 
-class TextManglersTestCase(TestCase):
+class TestTextManglers(TestCase):
     def test_convert_unicode(self):
         self.assertEqual(u'a-b c', convert_unicode(u'a\u2013b\xa0c'))
 
@@ -14,7 +14,7 @@ class TextManglersTestCase(TestCase):
     def test_is_unicode(self):
         self.assertFalse(is_unicode(u'@foo^bar!'))
         self.assertTrue(is_unicode(
-                u'foobar \n \u043f\u0440\u0435\u0432\u0435\u0434'))
+            u'foobar \n \u043f\u0440\u0435\u0432\u0435\u0434'))
 
 
 UNI_BIT = u'\u044d\u0442\u043e'
@@ -28,7 +28,7 @@ def long_unicode(bits=50, suffix=u''):
     return u' '.join([UNI_BIT] * bits) + suffix
 
 
-class ContentFormatterTestCase(TestCase):
+class TestContentFormatter(TestCase):
 
     def test_format_simple(self):
         cf = ContentFormatter(160, 70)

--- a/vumi_wikipedia/tests/test_text_manglers.py
+++ b/vumi_wikipedia/tests/test_text_manglers.py
@@ -95,7 +95,7 @@ class TestContentFormatter(TestCase):
     def test_format_more_very_long_words(self):
         """
         If we have a very long word at the start of our input, we split it in
-        the middle.
+        the middle, even if we have a nonzero start offset.
         """
         cf = ContentFormatter(160, 70)
         fmt = lambda txt, i: cf.format_more(txt, i, u' (more)', u' (no more)')

--- a/vumi_wikipedia/tests/test_text_manglers.py
+++ b/vumi_wikipedia/tests/test_text_manglers.py
@@ -69,3 +69,64 @@ class TestContentFormatter(TestCase):
                          fmt(long_ascii(), 4))
         self.assertEqual((55, u'...' + long_unicode(14, u' ... (more)')),
                          fmt(long_unicode(), 4))
+
+    def test_format_very_long_words(self):
+        """
+        If we have a very long word at the start of our input, we split it in
+        the middle.
+        """
+        cf = ContentFormatter(160, 70)
+
+        long_ascii_words = u' '.join([u'abc' * 60] * 2)
+        long_unicode_words = u' '.join([UNI_BIT * 25] * 2)
+
+        self.assertEqual(
+            long_ascii_words[:156] + u' ...', cf.format(long_ascii_words))
+        self.assertEqual(
+            long_unicode_words[:66] + u' ...', cf.format(long_unicode_words))
+
+        self.assertEqual(
+            long_ascii_words[:146] + u' ... (postfix)',
+            cf.format(long_ascii_words, u' (postfix)'))
+        self.assertEqual(
+            long_unicode_words[:56] + u' ... (postfix)',
+            cf.format(long_unicode_words, u' (postfix)'))
+
+    def test_format_more_very_long_words(self):
+        """
+        If we have a very long word at the start of our input, we split it in
+        the middle.
+        """
+        cf = ContentFormatter(160, 70)
+        fmt = lambda txt, i: cf.format_more(txt, i, u' (more)', u' (no more)')
+
+        long_ascii_words = u' '.join([u'abc' * 60] * 2)
+        long_unicode_words = u' '.join([UNI_BIT * 25] * 2)
+
+        self.assertEqual(
+            (149, long_ascii_words[:149] + u' ... (more)'),
+            fmt(long_ascii_words, 0))
+        self.assertEqual(
+            (31, u'...' + long_ascii_words[149:].split()[0] + u' ... (more)'),
+            fmt(long_ascii_words, 149))
+        # Add one to skip the space.
+        self.assertEqual(
+            (146, u'...' + long_ascii_words.split()[1][:146] + u' ... (more)'),
+            fmt(long_ascii_words, 149 + 31 + 1))
+        self.assertEqual(
+            (34, u'...' + long_ascii_words.split()[1][146:] + u' (no more)'),
+            fmt(long_ascii_words, 149 + 31 + 1 + 146))
+
+        self.assertEqual(
+            (59, long_unicode_words[:59] + u' ... (more)'),
+            fmt(long_unicode_words, 0))
+        self.assertEqual(
+            (16, u'...' + long_unicode_words[59:].split()[0] + u' ... (more)'),
+            fmt(long_unicode_words, 59))
+        # Add one to skip the space.
+        self.assertEqual(
+            (56, u'...' + long_unicode_words.split()[1][:56] + u' ... (more)'),
+            fmt(long_unicode_words, 59 + 16 + 1))
+        self.assertEqual(
+            (19, u'...' + long_unicode_words.split()[1][56:] + u' (no more)'),
+            fmt(long_unicode_words, 59 + 16 + 1 + 56))

--- a/vumi_wikipedia/text_manglers.py
+++ b/vumi_wikipedia/text_manglers.py
@@ -94,6 +94,13 @@ class ContentFormatter(object):
         # It doesn't all fit, so we need ellipsis and `more`
         return self._format(text, more, extra_len)
 
+    def _truncate_text(self, text, max_length):
+        truncated_text = text.rsplit(None, 1)[0]
+        if truncated_text == text:
+            # We have a single long "word", so split it in the middle.
+            truncated_text = text[:max_length]
+        return truncated_text
+
     def _format(self, content, postfix, extra_len):
         text = content
 
@@ -103,8 +110,9 @@ class ContentFormatter(object):
 
         # It doesn't all fit, so we need ellipsis and `postfix`
         postfix = self.post_ellipsis + postfix
-        while len(text) > self.get_limit(text, len(postfix)):
-            text = text.rsplit(None, 1)[0]
+        max_length = self.get_limit(text, len(postfix))
+        while len(text) > max_length:
+            text = self._truncate_text(text, max_length)
 
         # Try to break on sentence end if that won't cost too many characters.
         if self.sentence_break_threshold > 0:


### PR DESCRIPTION
If the input to `ContentFormatter._format()` starts with a word that is longer than the allowed message length, it spins forever.