### PR TITLE
Switch default URL to HTTPS

### DIFF
--- a/vumi_wikipedia/wikipedia.py
+++ b/vumi_wikipedia/wikipedia.py
@@ -49,7 +49,7 @@ class WikipediaConfig(ApplicationWorker.CONFIG_CLASS):
         " Wikipedia. Any recent enough MediaWiki installation should be fine,"
         " although certain assumptions are made about the structure of"
         " articles that may not hold outside of Wikipedia.",
-        default='http://en.wikipedia.org/w/api.php')
+        default='https://en.wikipedia.org/w/api.php')
 
     api_timeout = ConfigInt("API call timeout in seconds.", default=5)
     include_url_in_sms = ConfigBool(

--- a/vumi_wikipedia/wikipedia_api.py
+++ b/vumi_wikipedia/wikipedia_api.py
@@ -140,7 +140,7 @@ class WikipediaAPI(object):
     :param bool gzip: `True` to ask for gzip encoding, `False` otherwise.
     """
 
-    URL = 'http://en.wikipedia.org/w/api.php'
+    URL = 'https://en.wikipedia.org/w/api.php'
 
     # The MediaWiki API docs request that clients use gzip encoding to reduce
     # network traffic. However, Twisted only supports this easily from 11.1.
@@ -189,7 +189,7 @@ class WikipediaAPI(object):
         :param int limit: Maximum number of results to return. (Default 9)
         :param unicode backend: The backend to use. Defaults to whatever
             Wikimedia uses. See
-            http://en.wikipedia.org/w/api.php?action=help&modules=query+search
+            https://en.wikipedia.org/w/api.php?action=help&modules=query+search
             for list of available backends.
 
         :returns: `list` of article titles matching search terms.


### PR DESCRIPTION
The HTTP endpoint is being redirected (301) to HTTPS. We should change the default endpoint accordingly.